### PR TITLE
Reduce per-instruction string storage

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -488,7 +488,7 @@ struct insn {
     bool useful; /* Used in DCE process. Set true if instruction is useful. */
     basic_block_t *belong_to;
     phi_operand_t *phi_ops;
-    char str[64];
+    char *str;
 };
 
 typedef struct {

--- a/src/globals.c
+++ b/src/globals.c
@@ -1090,11 +1090,12 @@ void add_insn(block_t *block,
     n->belong_to = bb;
     n->phi_ops = NULL;
     n->idx = 0;
+    n->str = NULL;
 
-    if (str)
-        strcpy(n->str, intern_string(str));
-    else
-        n->str[0] = '\0';
+    if (str && str[0]) {
+        char *interned = intern_string(str);
+        n->str = arena_strdup(INSN_ARENA, interned);
+    }
 
     /* Mark variables as address-taken to prevent incorrect constant
      * optimization
@@ -1486,7 +1487,7 @@ void dump_bb_insn(func_t *func, basic_block_t *bb, bool *at_func_start)
             break;
         case OP_call:
             print_indent(1);
-            printf("call @%s", insn->str);
+            printf("call @%s", insn->str ? insn->str : "");
             break;
         case OP_func_ret:
             print_indent(1);

--- a/src/reg-alloc.c
+++ b/src/reg-alloc.c
@@ -759,6 +759,8 @@ void reg_alloc(void)
                     REGS[ir->dest].polluted = 0;
                     break;
                 case OP_call:
+                    if (!insn->str)
+                        fatal("Call instruction missing callee name");
                     callee_func = find_func(insn->str);
                     if (!callee_func->num_params)
                         spill_alive(bb, insn);

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -1117,7 +1117,7 @@ void bb_dump(FILE *fd, func_t *func, basic_block_t *bb)
                         insn->rs1->subscript);
                 break;
             case OP_call:
-                sprintf(str, "<CALL @%s>", insn->str);
+                sprintf(str, "<CALL @%s>", insn->str ? insn->str : "");
                 break;
             case OP_indirect:
                 sprintf(str, "<INDIRECT CALL>");


### PR DESCRIPTION
## Summary
- replace the fixed 64-byte buffer in `insn_t` with a pointer so most instructions no longer reserve space for unused strings
- duplicate optional strings in the instruction arena only when needed and guard formatting/allocator code paths that reference them

## Testing
- `.ci/check-format.sh`
- `.ci/check-newline.sh`
- `make`
- `make check`
- `make check-snapshot`


------
https://chatgpt.com/codex/tasks/task_e_68c99dfd9ae48322aa860225b6971e07