### PR TITLE
Support continuation syntax for global variable declarations

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -4783,36 +4783,53 @@ void read_global_decl(block_t *block, bool is_const)
         if (lex_accept(T_semicolon)) /* forward definition */
             return;
         error("Syntax error in global declaration");
-    } else
+    }
+
+    type_t *base_type = var->type;
+
+    for (;;) {
         add_insn(block, GLOBAL_FUNC->bbs, OP_allocat, var, NULL, NULL, 0, NULL);
 
-    /* is a variable */
-    if (lex_accept(T_assign)) {
-        /* If '{' follows and this is an array (explicit or implicit-size via
-         * pointer syntax), reuse the array initializer to emit per-element
-         * stores for globals as well.
-         */
-        if (lex_peek(T_open_curly, NULL) &&
-            (var->array_size > 0 || var->ptr_level > 0)) {
-            parse_array_init(var, block, &GLOBAL_FUNC->bbs, true);
-            lex_expect(T_semicolon);
+        bool var_on_stack = !var->is_func;
+
+        if (lex_accept(T_assign)) {
+            /* If '{' follows and this is an array (explicit or implicit-size
+             * via pointer syntax), reuse the array initializer to emit
+             * per-element stores for globals as well.
+             */
+            if (lex_peek(T_open_curly, NULL) &&
+                (var->array_size > 0 || var->ptr_level > 0)) {
+                parse_array_init(var, block, &GLOBAL_FUNC->bbs, true);
+                var_on_stack = !var->is_func;
+            } else {
+                /* Otherwise fall back to scalar/constant global assignment */
+                read_global_assignment(var->var_name);
+                var_on_stack = false;
+            }
+        }
+
+        if (lex_accept(T_comma)) {
+            if (var_on_stack)
+                opstack_pop();
+
+            var_t *next = require_var(block);
+            next->is_global = true;
+            next->is_const_qualified = is_const;
+            next->type = base_type;
+            read_inner_var_decl(next, false, false);
+
+            var = next;
+            continue;
+        }
+
+        if (lex_accept(T_semicolon)) {
+            if (var_on_stack)
+                opstack_pop();
             return;
         }
 
-        /* Otherwise fall back to scalar/constant global assignment */
-        read_global_assignment(var->var_name);
-        lex_expect(T_semicolon);
-        return;
-    } else if (lex_accept(T_comma)) {
-        /* TODO: Implement global variable continuation syntax for multiple
-         * declarations in single statement (e.g., int a = 1, b = 2;)
-         */
-        error("Global continuation not supported");
-    } else if (lex_accept(T_semicolon)) {
-        opstack_pop();
-        return;
+        error("Syntax error in global declaration");
     }
-    error("Syntax error in global declaration");
 }
 
 void consume_global_compound_literal(void)

--- a/tests/driver.sh
+++ b/tests/driver.sh
@@ -1775,6 +1775,47 @@ int main()
 }
 EOF
 
+# Multiple declarators without initializers
+try_ 6 << EOF
+int g1, g2, g3;
+int main()
+{
+    g1 = 1;
+    g2 = 2;
+    g3 = 3;
+    return g1 + g2 + g3;
+}
+EOF
+
+# Multiple declarators with scalar initializers
+try_ 21 << EOF
+int gx = 7, gy = 14;
+int main()
+{
+    return gx + gy;
+}
+EOF
+
+# Array declarator followed by scalar declarator
+try_ 15 << EOF
+int numbers[2], extra = 7;
+int main()
+{
+    numbers[0] = 3;
+    numbers[1] = 5;
+    return numbers[0] + numbers[1] + extra;
+}
+EOF
+
+# Const-qualified declarators sharing a statement
+try_ 6 << EOF
+const int cx = 2, cy = 3;
+int main()
+{
+    return cx * cy;
+}
+EOF
+
 # Category: Const Qualifiers
 begin_category "Const Qualifiers" "Testing const qualifier support for variables and parameters"
 


### PR DESCRIPTION
## Summary
- allow the parser to reuse a base type across comma-separated global declarators and emit the appropriate initializers or pops
- extend the global-variable regression tests to cover multiple declarators, pointer/array mixes, and const-qualified continuations

## Testing
- make check
- make check-snapshot

------
https://chatgpt.com/codex/tasks/task_e_68c9eb0dccb48322bb62d1ec7cb20ecb