### PR TITLE
Optimize hashmap key storage to reduce arena usage

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -98,9 +98,9 @@ typedef struct {
 /* string-based hash map definitions */
 
 typedef struct hashmap_node {
-    char *key;
-    void *val;
     struct hashmap_node *next;
+    void *val;
+    char *key;
 } hashmap_node_t;
 
 typedef struct {

--- a/src/globals.c
+++ b/src/globals.c
@@ -431,30 +431,45 @@ hashmap_t *hashmap_create(int cap)
  *
  * Return: The pointer of created node.
  */
-hashmap_node_t *hashmap_node_new(char *key, void *val)
+hashmap_node_t *hashmap_node_new_internal(char *key, void *val, bool copy_key)
 {
     if (!key)
         return NULL;
 
-    const int len = strlen(key);
-    hashmap_node_t *node = arena_alloc(HASHMAP_ARENA, sizeof(hashmap_node_t));
+    hashmap_node_t *node;
 
+    if (copy_key) {
+        const int len = strlen(key);
+        const int alloc_size = (int) (sizeof(hashmap_node_t) + len + 1);
+        node = arena_alloc(HASHMAP_ARENA, alloc_size);
 
-    if (!node) {
-        printf("Failed to allocate hashmap_node_t\n");
-        return NULL;
+        if (!node) {
+            printf("Failed to allocate hashmap_node_t\n");
+            return NULL;
+        }
+
+        char *key_storage = (char *) (node + 1);
+        memcpy(key_storage, key, len + 1);
+        node->key = key_storage;
+    } else {
+        node = arena_alloc(HASHMAP_ARENA, sizeof(hashmap_node_t));
+
+        if (!node) {
+            printf("Failed to allocate hashmap_node_t\n");
+            return NULL;
+        }
+
+        node->key = key;
     }
 
-    node->key = arena_alloc(HASHMAP_ARENA, len + 1);
-    if (!node->key) {
-        printf("Failed to allocate hashmap_node_t key with size %d\n", len + 1);
-        return NULL;
-    }
-
-    strcpy(node->key, key);
-    node->val = val;
     node->next = NULL;
+    node->val = val;
     return node;
+}
+
+hashmap_node_t *hashmap_node_new(char *key, void *val)
+{
+    return hashmap_node_new_internal(key, val, true);
 }
 
 void hashmap_rehash(hashmap_t *map)
@@ -508,14 +523,13 @@ void hashmap_rehash(hashmap_t *map)
  * @val: The value pointer. May be NULL. This value's lifetime is held by
  * hashmap.
  */
-void hashmap_put(hashmap_t *map, char *key, void *val)
+void hashmap_insert_node(hashmap_t *map, hashmap_node_t *new_node)
 {
-    if (!map)
+    if (!map || !new_node)
         return;
 
-    int index = hashmap_hash_index(map->cap, key);
-    hashmap_node_t *cur = map->buckets[index],
-                   *new_node = hashmap_node_new(key, val);
+    int index = hashmap_hash_index(map->cap, new_node->key);
+    hashmap_node_t *cur = map->buckets[index];
 
     if (!cur) {
         map->buckets[index] = new_node;
@@ -529,6 +543,16 @@ void hashmap_put(hashmap_t *map, char *key, void *val)
     /* Check if size of map exceeds load factor 75% (or 3/4 of capacity) */
     if ((map->cap >> 2) + (map->cap >> 1) <= map->size)
         hashmap_rehash(map);
+}
+
+void hashmap_put(hashmap_t *map, char *key, void *val)
+{
+    hashmap_insert_node(map, hashmap_node_new_internal(key, val, true));
+}
+
+void hashmap_put_interned(hashmap_t *map, char *key, void *val)
+{
+    hashmap_insert_node(map, hashmap_node_new_internal(key, val, false));
 }
 
 /* Get key-value pair node from hashmap from given key.
@@ -684,8 +708,9 @@ void add_alias(char *alias, char *value)
             return;
         }
         /* Use interned string for alias name */
-        strcpy(al->alias, intern_string(alias));
-        hashmap_put(ALIASES_MAP, alias, al);
+        char *interned = intern_string(alias);
+        strcpy(al->alias, interned);
+        hashmap_put_interned(ALIASES_MAP, al->alias, al);
     }
     strcpy(al->value, value);
     al->disabled = false;
@@ -719,8 +744,9 @@ macro_t *add_macro(char *name)
             return NULL;
         }
         /* Use interned string for macro name */
-        strcpy(ma->name, intern_string(name));
-        hashmap_put(MACROS_MAP, name, ma);
+        char *interned = intern_string(name);
+        strcpy(ma->name, interned);
+        hashmap_put_interned(MACROS_MAP, ma->name, ma);
     }
     ma->disabled = false;
     return ma;
@@ -775,7 +801,7 @@ char *intern_string(char *str)
     interned = arena_alloc(GENERAL_ARENA, len);
     strcpy(interned, str);
 
-    hashmap_put(string_pool->strings, interned, interned);
+    hashmap_put_interned(string_pool->strings, interned, interned);
 
     return interned;
 }
@@ -822,9 +848,10 @@ void add_constant(char alias[], int value)
     }
 
     /* Use interned string for constant name */
-    strcpy(constant->alias, intern_string(alias));
+    char *interned_alias = intern_string(alias);
+    strcpy(constant->alias, interned_alias);
     constant->value = value;
-    hashmap_put(CONSTANTS_MAP, alias, constant);
+    hashmap_put_interned(CONSTANTS_MAP, constant->alias, constant);
 }
 
 constant_t *find_constant(char alias[])
@@ -925,9 +952,10 @@ func_t *add_func(char *func_name, bool synthesize)
         return func;
 
     func = arena_alloc_func();
-    hashmap_put(FUNC_MAP, func_name, func);
+    char *interned_name = intern_string(func_name);
+    hashmap_put_interned(FUNC_MAP, interned_name, func);
     /* Use interned string for function name */
-    strcpy(func->return_def.var_name, intern_string(func_name));
+    strcpy(func->return_def.var_name, interned_name);
     func->stack_size = 4;
 
     if (synthesize)


### PR DESCRIPTION
## Summary
- allocate hashmap nodes and their key bytes from a single arena allocation
- add a no-copy hashmap insertion path and use it for interned aliases, macros, constants, and functions
- reuse interned strings in the string pool to avoid duplicating key storage

## Testing
- make check
- make check-snapshot
- make sanitizer
- make check-sanitizer

------
https://chatgpt.com/codex/tasks/task_e_68ca05f852fc8322aca755376fe51568